### PR TITLE
add "run" to Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ parts
 docs/_build
 cover/
 .tox
+.coverage

--- a/terminal/command.py
+++ b/terminal/command.py
@@ -197,13 +197,15 @@ class Command(object):
     """
 
     def __init__(self, name, description=None, version=None, usage=None,
-                 title=None, func=None, help_footer=None, arguments=None):
+                 title=None, func=None, run=None, help_footer=None,
+                 arguments=None):
         self._name = name
         self._description = description
         self._version = version
         self._usage = usage
         self._title = title
         self._command_func = func
+        self._command_run = run
         self._help_footer = help_footer
         self._positional_list = arguments or []
 
@@ -473,6 +475,10 @@ class Command(object):
         """Alias for Command.action."""
         return self.action(command)
 
+    def run(self, command):
+        if self._command_run:
+            self._command_run(command)
+
     def parse(self, argv=None):
         """
         Parse argv of terminal
@@ -521,6 +527,8 @@ class Command(object):
 
         if self._command_func:
             self._command_func(**self._results)
+        else:
+            self.run(self)
         return self
 
     def print_version(self):

--- a/terminal/command.py
+++ b/terminal/command.py
@@ -496,6 +496,8 @@ class Command(object):
             self.validate_options()
             if self._command_func:
                 self._command_func(**self._results)
+            else:
+                self.run(self)
             return self
 
         cmd = self._argv[0]

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -177,6 +177,44 @@ class TestCommand(object):
 
         program.print_help()
 
+    def test_run1(self):
+
+        def bar(command):
+            assert command.bar == 'lepture'
+            command.print_help()
+
+        program = Command('runfoo1', run=bar)
+        program.option('-b, --bar <bar>', "foo bar")
+        program.parse('runfoo1 -b lepture')
+        assert program.bar == 'lepture'
+        program.print_help()
+
+    def test_run2(self):
+        program = Command('runfoo2')
+
+        def bar(command):
+            assert command.bar == 'lepture'
+            command.print_help()
+
+        # subcommand
+        subcommand = Command('subfoo', run=bar)
+        subcommand.option('-b, --bar <bar>', "foo bar")
+        program.action(subcommand)
+        program.parse('runfoo2 subfoo -b lepture')
+        program.print_help()
+
+    def test_run3(self):
+        program = Command('runfoo3')
+        program.option('-b, --bar <bar>', "foo bar")
+
+        def bar(command):
+            assert command.bar == 'lepture'
+            command.print_help()
+
+        program.run = bar
+        program.parse('runfoo3 -b lepture')
+        program.print_help()
+
     def test_func(self):
         def bar():
             return 'bar'


### PR DESCRIPTION
```
(dev2)# cat aa.py
from terminal import Command, red

def show(cmd):
    """
    foo's subcommand run

    :parms cmd: foo command
    """

    if cmd.color:
        print(red('show'))
    else:
        print('show')

cmd_show = Command('show', 'show something', version='1.0.0', run=show)
cmd_show.option('-c, --color', 'disable or enable colors')

cmd_show2 = Command('show2', 'show2 something', version='1.0.1')
cmd_show2.option('-c, --color', 'disable or enable colors')
cmd_show2.run = show
(dev2)#
(dev2)# cat bb.py
from terminal import Command
from aa import cmd_show, cmd_show2

program = Command('foo', version='1.0.0')
program.action(cmd_show)
program.action(cmd_show2)

program.parse()
(dev2)#
(dev2)# python bb.py -h

  foo 1.0.0

  Usage: foo <command> [option]

  Options:

    -h, --help      output the help menu
    -V, --version   output the version number

  Commands:

    show            show something
    show2           show2 something

(dev2)# python bb.py show
show
(dev2)# python bb.py show -c
show
(dev2)# python bb.py show2
show
(dev2)# python bb.py show2 -c
show
(dev2)#
```
